### PR TITLE
ci: Add firmware build workflow

### DIFF
--- a/.github/workflows/build_check.yaml
+++ b/.github/workflows/build_check.yaml
@@ -1,0 +1,25 @@
+---
+name: Build-check
+
+on:
+  pull_request:
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: "recursive"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Build PlatformIO Project
+        run: pio run -e esp32-s3

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,7 +15,7 @@ extra_configs =
 	libraries.ini
 
 [env]
-platform = https://github.com/platformio/platform-espressif32.git#4b44a501c9229053eba72987d77c9c3d60cbbc60
+platform = https://github.com/platformio/platform-espressif32.git @ ^6.3.2
 framework = espidf
 test_framework = unity
 debug_test = *


### PR DESCRIPTION
Can be used as a pull request check.

Platform-espressif32 update is needed to workaround [this](https://community.platformio.org/t/esp-idf-pyparsing-expecting-end-of-text/23562/9) issue.